### PR TITLE
Fix/gmount mount match

### DIFF
--- a/gmount/rclone_backend.py
+++ b/gmount/rclone_backend.py
@@ -13,7 +13,14 @@ class RcloneBackend:
         """Check if a path is mounted using the `mount` command."""
         try:
             mount_output = subprocess.check_output(['mount']).decode('utf-8')
-            return any(local_path.as_posix() in line for line in mount_output.splitlines())
+            mount_point_str = local_path.as_posix()
+            # Fix to check for exact match on the mount instead of the substring match originally being done.
+            # For example, /mnt/mybucket should not match /mnt/mybucket-backup.
+            # Check for " on {path} type " or ending with " on {path}" to ensure exact match.
+            for line in mount_output.splitlines():
+                if f" on {mount_point_str} type " in line or line.endswith(f" on {mount_point_str}"):
+                    return True
+            return False
         except subprocess.CalledProcessError:
             warning("Failed to get mount information from mount command")
             return False


### PR DESCRIPTION
fix for path match bug that was matching a substing instead of checking for the exact match on word boundaries. if the path `~/mnt/slhfile` was already mounted somewhere, gmount wouldn't mount '~/mnt/slh` since it would hit on `slhfile`

```bash
OK: Successfully mounted //localhost/DATA to /home/bladertm/mnt/slhdatamiseq
Info: localhost:4451//SLH is already mounted at /home/bladertm/mnt/slh
```
Fixed by matching betwen 'on ' and ' type', or after ' on ' at the end of the mount output string.